### PR TITLE
power_profile.xml: Correct battery capacity

### DIFF
--- a/overlay/frameworks/base/core/res/res/xml/power_profile.xml
+++ b/overlay/frameworks/base/core/res/res/xml/power_profile.xml
@@ -71,7 +71,7 @@
     <array name="memory.bandwidths">
         <value>22.7</value>
     </array>
-    <item name="battery.capacity">4000</item>
+    <item name="battery.capacity">4500</item>
     <item name="wifi.controller.idle">0.19</item>
     <item name="wifi.controller.rx">148.18</item>
     <item name="wifi.controller.tx">395.03</item>


### PR DESCRIPTION
This should provide more accurate remaining time of battery and etc.
The capacity of PDX215 is 4500mAh not 4000